### PR TITLE
webos-connman-adapter.role.json.in: Add permissions for com.webos.ser…

### DIFF
--- a/files/sysbus/webos-connman-adapter.role.json.in
+++ b/files/sysbus/webos-connman-adapter.role.json.in
@@ -11,7 +11,8 @@
                         "com.webos.service.wifi",
                         "com.webos.service.config",
                         "com.webos.service.connectionmanager",
-                        "com.webos.service.downloadmanager"]
+                        "com.webos.service.downloadmanager",
+                        "com.webos.lunasend-*"]
         },
         {
             "service":"com.webos.service.connectionmanager",
@@ -19,7 +20,8 @@
                         "com.webos.settingsservice",
                         "com.webos.service.wifi",
                         "com.webos.service.config",
-                        "com.webos.service.downloadmanager"]
+                        "com.webos.service.downloadmanager",
+                        "com.webos.lunasend-*"]
         }
     ]
 }

--- a/files/sysbus/webos-connman-adapter.role.json.in
+++ b/files/sysbus/webos-connman-adapter.role.json.in
@@ -10,14 +10,16 @@
                         "com.webos.settingsservice",
                         "com.webos.service.wifi",
                         "com.webos.service.config",
-                        "com.webos.service.connectionmanager"]
+                        "com.webos.service.connectionmanager",
+                        "com.webos.service.downloadmanager"]
         },
         {
             "service":"com.webos.service.connectionmanager",
             "outbound":["com.webos.service.pdm",
                         "com.webos.settingsservice",
                         "com.webos.service.wifi",
-                        "com.webos.service.config"]
+                        "com.webos.service.config",
+                        "com.webos.service.downloadmanager"]
         }
     ]
 }


### PR DESCRIPTION
…vice.downloadmanager

Fixes:

Oct 02 07:51:15 qemux86-64 LunaDownloadMgr[569]: [] [pmlog] DownloadMgr RECEIVED_FSCK_SIGNAL {"detail":"received fsck signal from storaged"}
Oct 02 07:51:15 qemux86-64 ls-hubd[291]: [] [pmlog] ls-hubd MSG_TRUNCATED {"MSGID":"LSHUB_NO_NAME_PERMS","CAUSE":"Log message exceeded 1024 bytes","TRUNCATED_MSG":"Can not find match for 'com.webos.service.downloadmanager' in pattern queue '[\"org.webosports.wifi\", \"org.webosports.systemserv ..."}
Oct 02 07:51:15 qemux86-64 ls-hubd[291]: [] [pmlog] ls-hubd LSHUB_NO_NAME_PERMS {} Can not find match for 'com.webos.service.downloadmanager' in pattern queue '["org.webosports.wifi", "org.webosports.systemservice", "org.webosports.settingsservice", "org.webosports.service.wifi", "org.webosports.service.systemservice", "org.webosports.service.settingsservice", "org.webosports.service.pdm", "org.webosports.service.eventmonitor", "org.webosports.service.connectionmanager", "org.webosports.service.config", "org.webosports.service.activitymanager.client", "org.webosports.pdm", "org.webosports.eventmonitor", "org.webosports.connectionmanager", "org.webosports.config", "org.webosports.activitymanager.client", "org.webosinternals.wifi", "org.webosinternals.systemservice", "org.webosinternals.settingsservice", "org.webosinternals.service.wifi", "org.webosinternals.service.systemservice", "org.webosinternals.service.settingsservice", "org.webosinternals.service.pdm", "org.webosinternals.service.eventmonitor", "org.webosinternals.service.connectionmanager", "org.webosinternals.service.config", "o
Oct 02 07:51:15 qemux86-64 ls-hubd[291]: [] [pmlog] ls-hubd LSHUB_NO_OUT_PERMS {"DEST_APP_ID":"com.webos.service.downloadmanager","SRC_APP_ID":"com.webos.service.connectionmanager","EXE":"/usr/sbin/webos-connman-adapter","PID":522} "com.webos.service.connectionmanager" does not have sufficient outbound permissions to communicate with "com.webos.service.downloadmanager" (cmdline: /usr/sbin/webos-connman-adapter)

Upstream-Status: Pending